### PR TITLE
Adding configurable batch size to pull consumer streams

### DIFF
--- a/capability-provider/Cargo.lock
+++ b/capability-provider/Cargo.lock
@@ -74,34 +74,34 @@ checksum = "ca6c635b3aa665c649ad1415f1573c85957dfa47690ec27aebe7ec17efe3c643"
 
 [[package]]
 name = "async-nats"
-version = "0.27.1"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47a445ce9f6605511fe594b31a6ba174bc874fef6bfa628cea51e9bfe450e2f7"
+checksum = "94e3e851ddf3b62be8a8085e1e453968df9cdbf990a37bbb589b5b4f587c68d7"
 dependencies = [
- "base64 0.13.1",
- "base64-url",
+ "base64 0.21.0",
  "bytes",
  "futures",
  "http",
- "itertools",
  "itoa",
- "lazy_static",
+ "memchr",
  "nkeys",
- "nuid",
+ "nuid 0.3.2",
  "once_cell",
+ "rand",
  "regex",
  "ring",
  "rustls-native-certs",
  "rustls-pemfile",
+ "rustls-webpki",
  "serde",
  "serde_json",
  "serde_nanos",
  "serde_repr",
- "subslice",
+ "thiserror",
  "time 0.3.20",
  "tokio",
  "tokio-retry",
- "tokio-rustls",
+ "tokio-rustls 0.24.1",
  "tracing",
  "url",
 ]
@@ -250,15 +250,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
 
 [[package]]
-name = "base64-url"
-version = "1.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67a99c239d0c7e77c85dddfa9cebce48704b3c49550fcd3b84dd637e4484899f"
-dependencies = [
- "base64 0.13.1",
-]
-
-[[package]]
 name = "base64ct"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -296,6 +287,12 @@ checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
 
 [[package]]
 name = "byteorder"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fc10e8cc6b2580fda3f36eb6dc5316657f812a3df879a44a66fc9f0fdbc4855"
+
+[[package]]
+name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
@@ -305,6 +302,9 @@ name = "bytes"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "case"
@@ -408,7 +408,7 @@ dependencies = [
 
 [[package]]
 name = "concordance"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -506,7 +506,7 @@ version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b9fdf9972b2bd6af2d913799d9ebc165ea4d2e65878e329d9c6b372c4491b61"
 dependencies = [
- "byteorder",
+ "byteorder 1.4.3",
  "digest 0.9.0",
  "rand_core 0.5.1",
  "subtle",
@@ -685,12 +685,12 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.8.4"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3"
+checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
 dependencies = [
- "atty",
  "humantime",
+ "is-terminal",
  "log",
  "regex",
  "termcolor",
@@ -1040,9 +1040,9 @@ checksum = "1788965e61b367cd03a62950836d5cd41560c3577d90e40e0819373194d1661c"
 dependencies = [
  "http",
  "hyper",
- "rustls",
+ "rustls 0.20.8",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.23.4",
 ]
 
 [[package]]
@@ -1167,6 +1167,12 @@ name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
+name = "leb128"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "lexical-sort"
@@ -1295,12 +1301,13 @@ checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
 name = "nkeys"
-version = "0.2.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e66a7cd1358277b2a6f77078e70aea7315ff2f20db969cc61153103ec162594"
+checksum = "3e9261eb915c785ea65708bc45ef43507ea46914e1a73f1412d1a38aba967c8e"
 dependencies = [
- "byteorder",
+ "byteorder 1.4.3",
  "data-encoding",
+ "ed25519",
  "ed25519-dalek",
  "getrandom",
  "log",
@@ -1325,6 +1332,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20c1bb65186718d348306bf1afdeb20d9ab45b2ab80fb793c0fdcf59ffbb4f38"
 dependencies = [
  "lazy_static",
+ "rand",
+]
+
+[[package]]
+name = "nuid"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b61b1710432e483e6a67b20b6c60c6afe0e2fad67aabba3bdb912f3f70ff6ae"
+dependencies = [
+ "once_cell",
  "rand",
 ]
 
@@ -1459,12 +1476,6 @@ name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
-
-[[package]]
-name = "parity-wasm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be5e13c266502aadf83426d87d81a0f5d1ef45b8027f5a471c360abfe4bfae92"
 
 [[package]]
 name = "parking_lot"
@@ -1838,13 +1849,13 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls",
+ "rustls 0.20.8",
  "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.23.4",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -1875,7 +1886,7 @@ version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44519172358fd6d58656c86ab8e7fbc9e1490c3e8f14d35ed78ca0dd07403c9f"
 dependencies = [
- "byteorder",
+ "byteorder 1.4.3",
  "num-traits",
  "paste",
 ]
@@ -1886,7 +1897,7 @@ version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5b13be192e0220b8afb7222aa5813cb62cc269ebb5cac346ca6487681d2913e"
 dependencies = [
- "byteorder",
+ "byteorder 1.4.3",
  "rmp",
  "serde",
 ]
@@ -1930,6 +1941,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.21.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79ea77c539259495ce8ca47f53e66ae0330a8819f67e23ac96ca02f50e7b7d36"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki",
+ "sct",
+]
+
+[[package]]
 name = "rustls-native-certs"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1948,6 +1971,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
 dependencies = [
  "base64 0.21.0",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513722fd73ad80a71f72b61009ea1b584bcfa1483ca93949c8f290298837fa59"
+dependencies = [
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -2225,15 +2258,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
-name = "subslice"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0a8e4809a3bb02de01f1f7faf1ba01a83af9e8eabcd4d31dd6e413d14d56aae"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "subtle"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2425,9 +2449,19 @@ version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
 dependencies = [
- "rustls",
+ "rustls 0.20.8",
  "tokio",
  "webpki",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+dependencies = [
+ "rustls 0.21.5",
+ "tokio",
 ]
 
 [[package]]
@@ -2796,9 +2830,9 @@ dependencies = [
 
 [[package]]
 name = "wascap"
-version = "0.8.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32d1cfad67501627ac9344cbd89be80d2d5ebc98ef3b86862041cb26a280081f"
+checksum = "c38c03de923f80027cb62281f520bd97245a38eeb85a53f435a110509d044551"
 dependencies = [
  "base64 0.13.1",
  "data-encoding",
@@ -2807,12 +2841,14 @@ dependencies = [
  "lazy_static",
  "log",
  "nkeys",
- "nuid",
- "parity-wasm",
+ "nuid 0.4.1",
  "ring",
  "serde",
  "serde_derive",
  "serde_json",
+ "wasm-encoder",
+ "wasm-gen",
+ "wasmparser",
 ]
 
 [[package]]
@@ -2894,6 +2930,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
 
 [[package]]
+name = "wasm-encoder"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18c41dbd92eaebf3612a39be316540b8377c871cb9bde6b064af962984912881"
+dependencies = [
+ "leb128",
+]
+
+[[package]]
+name = "wasm-gen"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b854b1461005a7b3365742310f7faa3cac3add809d66928c64a40c7e9e842ebb"
+dependencies = [
+ "byteorder 0.5.3",
+ "leb128",
+]
+
+[[package]]
 name = "wasmbus-macros"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2907,9 +2962,9 @@ dependencies = [
 
 [[package]]
 name = "wasmbus-rpc"
-version = "0.12.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e61f6be0a90660de63951fb782dbb37979d03203c60176b6041ec36f6d367136"
+checksum = "2da4e25698e9e15af56e9bb510d233495c4ec9c6bbbf13d046205190dd4ab935"
 dependencies = [
  "async-nats",
  "async-trait",
@@ -2943,6 +2998,16 @@ dependencies = [
  "wascap",
  "wasmbus-macros",
  "weld-codegen",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.107.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29e3ac9b780c7dda0cac7a52a5d6d2d6707cc6e3451c9db209b6c758f40d7acb"
+dependencies = [
+ "indexmap",
+ "semver",
 ]
 
 [[package]]

--- a/capability-provider/Cargo.toml
+++ b/capability-provider/Cargo.toml
@@ -1,18 +1,18 @@
 [package]
 name = "concordance"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 
 [dependencies]
 async-trait = "0.1"
-async-nats = "0.27.1"
+async-nats = "0.30.0"
 anyhow = "1"
 futures = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_bytes = "0.11"
-wasmbus-rpc = {version = "0.12.0", features = ["otel"] }
+wasmbus-rpc = {version = "0.14.0", features = ["otel"] }
 tokio = { version = "1", features = ["full"] }
 uuid = { version = "1.3.0", features  = ["v4"]}
 tracing = "0.1"

--- a/capability-provider/src/config.rs
+++ b/capability-provider/src/config.rs
@@ -19,6 +19,7 @@ const ROLE_KEY: &str = "role";
 const INTEREST_KEY: &str = "interest";
 const ENTITY_NAME_KEY: &str = "name";
 const KEY_FIELD_KEY: &str = "key";
+const MAX_MESSAGES_PER_BATCH_KEY: &str = "max_messages_per_batch";
 
 const REQUIRED_KEYS: &[&str] = &["role", "interest", "name"];
 
@@ -26,6 +27,8 @@ const ROLE_AGGREGATE: &str = "aggregate";
 const ROLE_PROJECTOR: &str = "projector";
 const ROLE_PROCESS_MANAGER: &str = "process_manager";
 const ROLE_NOTIFIER: &str = "notifier";
+
+const DEFAULT_BATCH_MAX: usize = 200; // this is the default set by the NATS client when you leave the value off
 
 #[derive(Clone, Serialize, Deserialize)]
 pub struct BaseConfiguration {
@@ -107,6 +110,14 @@ impl InterestDeclaration {
             .cloned()
             .map(|s| s.as_str().unwrap_or_default().trim().to_string())
             .unwrap_or_default()
+    }
+
+    pub fn extract_max_messages_per_batch(&self) -> usize {
+        self.link_definition
+            .values
+            .get(MAX_MESSAGES_PER_BATCH_KEY)
+            .map(|s| s.parse::<usize>().unwrap_or(DEFAULT_BATCH_MAX))
+            .unwrap_or(DEFAULT_BATCH_MAX)
     }
 }
 

--- a/capability-provider/src/consumers/command_consumer.rs
+++ b/capability-provider/src/consumers/command_consumer.rs
@@ -72,7 +72,7 @@ impl CommandConsumer {
 
         let messages = consumer
             .stream()
-            .max_messages_per_batch(1)
+            .max_messages_per_batch(interest.extract_max_messages_per_batch())
             .messages()
             .await?;
         Ok(CommandConsumer { stream: messages })

--- a/capability-provider/src/consumers/event_consumer.rs
+++ b/capability-provider/src/consumers/event_consumer.rs
@@ -63,7 +63,7 @@ impl EventConsumer {
         let info = consumer.cached_info();
         let messages = consumer
             .stream()
-            .max_messages_per_batch(1)
+            .max_messages_per_batch(interest.extract_max_messages_per_batch())
             .messages()
             .await?;
         Ok(EventConsumer {

--- a/capability-provider/src/consumers/mod.rs
+++ b/capability-provider/src/consumers/mod.rs
@@ -64,7 +64,7 @@ macro_rules! impl_Stream {
             fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
                 match self.stream.try_poll_next_unpin(cx) {
                     Poll::Ready(None) => Poll::Ready(None),
-                    Poll::Ready(Some(Err(e))) => Poll::Ready(Some(Err(e))),
+                    Poll::Ready(Some(Err(e))) => Poll::Ready(Some(Err(Box::new(e)))),
                     Poll::Ready(Some(Ok(msg))) => {
                         // Convert to our $u type, skipping if we can't do it (and looping around to
                         // try the next poll)

--- a/capability-provider/src/natsclient/mod.rs
+++ b/capability-provider/src/natsclient/mod.rs
@@ -59,7 +59,7 @@ impl<T> AckableMessage<T> {
     }
 
     pub async fn nack(&mut self) {
-        if let Err(e) = self.custom_ack(AckKind::Nak).await {
+        if let Err(e) = self.custom_ack(AckKind::Nak(None)).await {
             error!(error = %e, "Error when nacking message");
             self.acker = None;
         }
@@ -87,7 +87,7 @@ impl<T> Drop for AckableMessage<T> {
         if let Some(msg) = self.acker.take() {
             if let Ok(handle) = tokio::runtime::Handle::try_current() {
                 handle.spawn(async move {
-                    if let Err(e) = msg.ack_with(AckKind::Nak).await {
+                    if let Err(e) = msg.ack_with(AckKind::Nak(None)).await {
                         warn!(error = %e, "Error when sending nack during drop")
                     }
                 });

--- a/capability-provider/src/state.rs
+++ b/capability-provider/src/state.rs
@@ -51,11 +51,15 @@ impl EntityState {
         trace!("Fetching state");
         let key = state_key(actor_role, entity_name, key);
 
-        self.bucket.get(&key).await.map_err(|err| {
-            let err_msg = format!("Failed to fetch state @ {key}: {err:?}");
-            error!(error = %err, message = err_msg);
-            RpcError::Nats(err_msg)
-        })
+        self.bucket
+            .get(&key)
+            .await
+            .map_err(|err| {
+                let err_msg = format!("Failed to fetch state @ {key}: {err:?}");
+                error!(error = %err, message = err_msg);
+                RpcError::Nats(err_msg)
+            })
+            .map(|b| b.map(|v| v.to_vec()))
     }
 
     #[instrument(level = "debug", skip(self))]

--- a/capability-provider/src/wcprovider.rs
+++ b/capability-provider/src/wcprovider.rs
@@ -178,7 +178,7 @@ impl ProviderHandler for ConcordanceProvider {
 
     #[instrument(level = "info", skip(self, ld), fields(actor_id = %ld.actor_id, provider_id = %ld.provider_id, link_name = %ld.link_name))]
     async fn put_link(&self, ld: &LinkDefinition) -> RpcResult<bool> {
-        let decls = match InterestDeclaration::from_linkdefinition(ld) {
+        let decls = match InterestDeclaration::from_linkdefinition(ld.clone()) {
             Ok(decls) => decls,
             Err(e) => {
                 error!("Failed to derive interest declarations from link definition. Aborting due to error: {e}");


### PR DESCRIPTION
Allows a link definition to supply `max_messages_per_batch` to control the batch size during pulls for performance tuning. The default value is `200`, which I was only able to determine by looking at the `async_nats` source code. 