### PR TITLE
Idiomatic implementation of an aggregate - bank account

### DIFF
--- a/examples/bankaccount/aggregate/src/commands.rs
+++ b/examples/bankaccount/aggregate/src/commands.rs
@@ -1,0 +1,199 @@
+use crate::*;
+
+pub(crate) fn handle_reserve_funds(
+    input: ReserveFunds,
+    state: Option<BankAccountAggregateState>,
+) -> Result<EventList> {
+    let Some(old_state) = state else {
+        return Err(anyhow::anyhow!(
+            "Rejected command to reserve funds. Account {} does not exist.",
+            input.account_number
+        ));
+    };
+    let avail_balance = old_state.available_balance();
+    if input.amount as u32 > avail_balance {
+        error!(
+            "Rejecting command to reserve funds, account {} does not have sufficient funds. Available {}",
+            &input.account_number, avail_balance
+        );
+        Ok(vec![])
+    } else {
+        Ok(vec![Event::new(
+            FundsReserved::TYPE,
+            STREAM,
+            &FundsReserved {
+                account_number: input.account_number.to_string(),
+                wire_transfer_id: input.wire_transfer_id,
+                customer_id: old_state.customer_id.to_string(),
+                amount: input.amount,
+            },
+        )])
+    }
+}
+
+pub(crate) fn handle_release_funds(
+    input: ReleaseFunds,
+    state: Option<BankAccountAggregateState>,
+) -> Result<EventList> {
+    let Some(old_state) = state else {
+        return Err(anyhow::anyhow!(
+            "Rejected command to release funds. Account {} does not exist.",
+            input.account_number
+        ));
+    };
+
+    if old_state
+        .reserved_funds
+        .contains_key(&input.wire_transfer_id)
+    {
+        Ok(vec![Event::new(
+            FundsReleased::TYPE,
+            STREAM,
+            &FundsReleased {
+                customer_id: input.customer_id,
+                account_number: input.account_number.to_string(),
+                wire_transfer_id: input.wire_transfer_id.to_string(),
+            },
+        )])
+    } else {
+        error!(
+                "Rejecting command to release funds, account {} does not have a wire transfer hold for {}",
+                &input.account_number, input.wire_transfer_id
+            );
+        Ok(vec![])
+    }
+}
+
+pub(crate) fn handle_commit_funds(
+    input: CommitFunds,
+    state: Option<BankAccountAggregateState>,
+) -> Result<EventList> {
+    let Some(old_state) = state else {
+        return Err(anyhow::anyhow!(
+            "Rejected command to commit funds. Account {} does not exist.",
+            input.account_number
+        ));
+    };
+
+    if old_state
+        .reserved_funds
+        .contains_key(&input.wire_transfer_id)
+    {
+        Ok(vec![Event::new(
+            FundsCommitted::TYPE,
+            STREAM,
+            &FundsCommitted {
+                customer_id: input.customer_id,
+                account_number: input.account_number.to_string(),
+                wire_transfer_id: input.wire_transfer_id.to_string(),
+            },
+        )])
+    } else {
+        error!(
+                "Rejecting command to commit funds, account {} does not have a wire transfer hold for {}",
+                &input.account_number, input.wire_transfer_id
+            );
+        Ok(vec![])
+    }
+}
+
+pub(crate) fn handle_create_account(input: CreateAccount) -> Result<EventList> {
+    Ok(vec![Event::new(
+        AccountCreated::TYPE,
+        STREAM,
+        &AccountCreated {
+            initial_balance: input.initial_balance,
+            account_number: input.account_number.to_string(),
+            min_balance: input.min_balance,
+            customer_id: input.customer_id,
+        },
+    )])
+}
+
+pub(crate) fn handle_withdraw_funds(
+    input: WithdrawFunds,
+    state: Option<BankAccountAggregateState>,
+) -> Result<EventList> {
+    let Some(state) = state else {
+        return Err(anyhow::anyhow!(
+            "Rejected command to withdraw funds. Account {} does not exist.",
+            input.account_number
+        ));
+    };
+
+    if state.available_balance() < input.amount as u32 {
+        error!(
+                "Rejecting command to withdraw funds, account {} does not have sufficient funds. Available {}",
+                &input.account_number, state.available_balance()
+            );
+        Ok(vec![])
+    } else {
+        Ok(vec![Event::new(
+            FundsWithdrawn::TYPE,
+            STREAM,
+            &FundsWithdrawn {
+                note: input.note,
+                account_number: input.account_number.to_string(),
+                amount: input.amount,
+                customer_id: input.customer_id,
+            },
+        )])
+    }
+}
+
+pub(crate) fn handle_wire_funds(
+    input: WireFunds,
+    state: Option<BankAccountAggregateState>,
+) -> Result<EventList> {
+    let Some(state) = state else {
+        return Err(anyhow::anyhow!(
+            "Rejected command to wire funds. Account {} does not exist.",
+            input.account_number
+        ));
+    };
+
+    if state.available_balance() < input.amount as u32 {
+        error!(
+                "Rejecting command to wire funds, account {} does not have sufficient funds. Available {}",
+                &input.account_number, state.available_balance()
+            );
+        Ok(vec![])
+    } else {
+        Ok(vec![Event::new(
+            WireTransferInitiated::TYPE,
+            STREAM,
+            &WireTransferInitiated {
+                note: input.note,
+                account_number: input.target_account_number,
+                target_routing_number: input.target_routing_number,
+                target_account_number: input.account_number,
+                amount: input.amount,
+                customer_id: input.customer_id,
+                wire_transfer_id: input.wire_transaction_id,
+            },
+        )])
+    }
+}
+
+pub(crate) fn handle_deposit_funds(
+    input: DepositFunds,
+    state: Option<BankAccountAggregateState>,
+) -> Result<EventList> {
+    if state.is_none() {
+        return Err(anyhow::anyhow!(
+            "Rejected command to deposit funds. Account {} does not exist.",
+            input.account_number
+        ));
+    };
+
+    Ok(vec![Event::new(
+        FundsDeposited::TYPE,
+        STREAM,
+        &FundsDeposited {
+            note: input.note,
+            account_number: input.account_number.to_string(),
+            amount: input.amount,
+            customer_id: input.customer_id,
+        },
+    )])
+}

--- a/examples/bankaccount/aggregate/src/events.rs
+++ b/examples/bankaccount/aggregate/src/events.rs
@@ -1,0 +1,119 @@
+use crate::*;
+
+impl From<AccountCreated> for BankAccountAggregateState {
+    fn from(input: AccountCreated) -> BankAccountAggregateState {
+        BankAccountAggregateState {
+            balance: input.initial_balance.unwrap_or(0) as _,
+            min_balance: input.min_balance.unwrap_or(0) as _,
+            account_number: input.account_number,
+            customer_id: input.customer_id,
+            reserved_funds: HashMap::new(),
+        }
+    }
+}
+
+pub(crate) fn apply_account_created(input: AccountCreated) -> Result<StateAck> {
+    Ok(StateAck::ok(Some(BankAccountAggregateState::from(input))))
+}
+
+pub(crate) fn apply_funds_deposited(
+    input: FundsDeposited,
+    state: Option<BankAccountAggregateState>,
+) -> Result<StateAck> {
+    let Some(state) = state else {
+        error!(
+            "Rejecting funds deposited event. Account {} does not exist.",
+            input.account_number
+        );
+        return Ok(StateAck::error(
+            "Account does not exist",
+            None::<BankAccountAggregateState>,
+        ));
+    };
+    let state = BankAccountAggregateState {
+        balance: state.balance + input.amount as u32,
+        ..state
+    };
+    Ok(StateAck::ok(Some(state)))
+}
+
+pub(crate) fn apply_funds_released(
+    input: FundsReleased,
+    state: Option<BankAccountAggregateState>,
+) -> Result<StateAck> {
+    let Some(state) = state else {
+        error!(
+            "Rejecting funds released event. Account {} does not exist.",
+            input.account_number
+        );
+        return Ok(StateAck::error(
+            "Account does not exist",
+            None::<BankAccountAggregateState>,
+        ));
+    };
+    let state = state.release_funds(&input.wire_transfer_id);
+    Ok(StateAck::ok(Some(state)))
+}
+
+pub(crate) fn apply_funds_committed(
+    input: FundsCommitted,
+    state: Option<BankAccountAggregateState>,
+) -> Result<StateAck> {
+    let Some(state) = state else {
+        error!(
+            "Rejecting funds committed event. Account {} does not exist.",
+            input.account_number
+        );
+        return Ok(StateAck::error(
+            "Account does not exist",
+            None::<BankAccountAggregateState>,
+        ));
+    };
+    let state = state.commit_funds(&input.wire_transfer_id);
+    Ok(StateAck::ok(Some(state)))
+}
+
+pub(crate) fn apply_funds_reserved(
+    input: FundsReserved,
+    state: Option<BankAccountAggregateState>,
+) -> Result<StateAck> {
+    let Some(state) = state else {
+        error!(
+            "Rejecting funds reserved event. Account {} does not exist.",
+            input.account_number
+        );
+        return Ok(StateAck::error(
+            "Account does not exist",
+            None::<BankAccountAggregateState>,
+        ));
+    };
+    let state = state.reserve_funds(&input.wire_transfer_id, input.amount as u32);
+    Ok(StateAck::ok(Some(state)))
+}
+
+pub(crate) fn apply_funds_withdrawn(
+    input: FundsWithdrawn,
+    state: Option<BankAccountAggregateState>,
+) -> Result<StateAck> {
+    let Some(state) = state else {
+        error!(
+            "Rejecting funds withdrawn event. Account {} does not exist.",
+            input.account_number
+        );
+        return Ok(StateAck::error(
+            "Account does not exist",
+            None::<BankAccountAggregateState>,
+        ));
+    };
+    let state = state.withdraw(input.amount as u32);
+    Ok(StateAck::ok(Some(state)))
+}
+
+pub(crate) fn apply_wire_transfer_initiated(
+    _input: WireTransferInitiated,
+    state: Option<BankAccountAggregateState>,
+) -> Result<StateAck> {
+    // We don't currently change internal state because of this. The first time a wire transfer
+    // impacts the the account is when funds are reserved (by the process manager)
+    Ok(StateAck::ok(state))
+}

--- a/examples/bankaccount/aggregate/src/lib.rs
+++ b/examples/bankaccount/aggregate/src/lib.rs
@@ -1,11 +1,15 @@
-use serde::{Deserialize, Serialize};
-use wasmcloud_interface_logging::{debug, error};
+use std::collections::HashMap;
 
-//use lunarfrontiers_model::*;
-#[derive(Serialize, Deserialize, Default, Debug, Clone)]
-pub struct BankAccountAggregateState {
-    pub placeholder: u16,
-}
+use serde::{Deserialize, Serialize};
+use wasmcloud_interface_logging::error;
+
+type Result<T> = anyhow::Result<T>;
+
+mod commands;
+mod events;
+mod state;
+
+use state::BankAccountAggregateState;
 
 concordance_gen::generate!({
     path: "../eventcatalog",
@@ -14,12 +18,13 @@ concordance_gen::generate!({
 });
 
 impl BankAccountAggregate for BankAccountAggregateImpl {
+    // -- Commands --
     fn handle_reserve_funds(
         &self,
         input: ReserveFunds,
         state: Option<BankAccountAggregateState>,
     ) -> anyhow::Result<EventList> {
-        todo!()
+        commands::handle_reserve_funds(input, state)
     }
 
     fn handle_release_funds(
@@ -27,7 +32,7 @@ impl BankAccountAggregate for BankAccountAggregateImpl {
         input: ReleaseFunds,
         state: Option<BankAccountAggregateState>,
     ) -> anyhow::Result<EventList> {
-        todo!()
+        commands::handle_release_funds(input, state)
     }
 
     fn handle_commit_funds(
@@ -35,15 +40,15 @@ impl BankAccountAggregate for BankAccountAggregateImpl {
         input: CommitFunds,
         state: Option<BankAccountAggregateState>,
     ) -> anyhow::Result<EventList> {
-        todo!()
+        commands::handle_commit_funds(input, state)
     }
 
     fn handle_create_account(
         &self,
         input: CreateAccount,
-        state: Option<BankAccountAggregateState>,
+        _state: Option<BankAccountAggregateState>,
     ) -> anyhow::Result<EventList> {
-        todo!()
+        commands::handle_create_account(input)
     }
 
     fn handle_withdraw_funds(
@@ -51,7 +56,7 @@ impl BankAccountAggregate for BankAccountAggregateImpl {
         input: WithdrawFunds,
         state: Option<BankAccountAggregateState>,
     ) -> anyhow::Result<EventList> {
-        todo!()
+        commands::handle_withdraw_funds(input, state)
     }
 
     fn handle_wire_funds(
@@ -59,7 +64,7 @@ impl BankAccountAggregate for BankAccountAggregateImpl {
         input: WireFunds,
         state: Option<BankAccountAggregateState>,
     ) -> anyhow::Result<EventList> {
-        todo!()
+        commands::handle_wire_funds(input, state)
     }
 
     fn handle_deposit_funds(
@@ -67,15 +72,17 @@ impl BankAccountAggregate for BankAccountAggregateImpl {
         input: DepositFunds,
         state: Option<BankAccountAggregateState>,
     ) -> anyhow::Result<EventList> {
-        todo!()
+        commands::handle_deposit_funds(input, state)
     }
+
+    // -- Events --
 
     fn apply_account_created(
         &self,
         input: AccountCreated,
-        state: Option<BankAccountAggregateState>,
+        _state: Option<BankAccountAggregateState>,
     ) -> anyhow::Result<StateAck> {
-        todo!()
+        events::apply_account_created(input)
     }
 
     fn apply_funds_deposited(
@@ -83,7 +90,7 @@ impl BankAccountAggregate for BankAccountAggregateImpl {
         input: FundsDeposited,
         state: Option<BankAccountAggregateState>,
     ) -> anyhow::Result<StateAck> {
-        todo!()
+        events::apply_funds_deposited(input, state)
     }
 
     fn apply_funds_released(
@@ -91,7 +98,7 @@ impl BankAccountAggregate for BankAccountAggregateImpl {
         input: FundsReleased,
         state: Option<BankAccountAggregateState>,
     ) -> anyhow::Result<StateAck> {
-        todo!()
+        events::apply_funds_released(input, state)
     }
 
     fn apply_funds_committed(
@@ -99,7 +106,7 @@ impl BankAccountAggregate for BankAccountAggregateImpl {
         input: FundsCommitted,
         state: Option<BankAccountAggregateState>,
     ) -> anyhow::Result<StateAck> {
-        todo!()
+        events::apply_funds_committed(input, state)
     }
 
     fn apply_funds_reserved(
@@ -107,7 +114,7 @@ impl BankAccountAggregate for BankAccountAggregateImpl {
         input: FundsReserved,
         state: Option<BankAccountAggregateState>,
     ) -> anyhow::Result<StateAck> {
-        todo!()
+        events::apply_funds_reserved(input, state)
     }
 
     fn apply_funds_withdrawn(
@@ -115,7 +122,7 @@ impl BankAccountAggregate for BankAccountAggregateImpl {
         input: FundsWithdrawn,
         state: Option<BankAccountAggregateState>,
     ) -> anyhow::Result<StateAck> {
-        todo!()
+        events::apply_funds_withdrawn(input, state)
     }
 
     fn apply_wire_transfer_initiated(
@@ -123,371 +130,8 @@ impl BankAccountAggregate for BankAccountAggregateImpl {
         input: WireTransferInitiated,
         state: Option<BankAccountAggregateState>,
     ) -> anyhow::Result<StateAck> {
-        todo!()
+        events::apply_wire_transfer_initiated(input, state)
     }
 }
 
 const STREAM: &str = "bankaccount";
-/*
-impl BankaccountAggregate for BankaccountAggregateImpl {
-    /* --- Command Handlers --- */
-
-    fn handle_create_account(
-        &self,
-        cmd: CreateAccount,
-        _state: Option<BankaccountAggregateState>,
-    ) -> Result<EventList> {
-        Ok(vec![Event::new(
-            AccountCreated::TYPE,
-            STREAM,
-            &AccountCreated {
-                initial_balance: cmd.initial_balance,
-                account_number: cmd.account_number.to_string(),
-                min_balance: cmd.min_balance,
-                customer_id: cmd.customer_id,
-            },
-        )])
-    }
-
-    fn handle_reserve_funds(
-        &self,
-        cmd: ReserveFunds,
-        state: Option<BankaccountAggregateState>,
-    ) -> Result<EventList> {
-        let Some(old_state) = state else {
-            error!(
-                "Rejected incoming command to reserve funds. Account {} does not exist.",
-                cmd.account_number
-            );
-            return Ok(vec![]);
-        };
-        let avail_balance = old_state.balance - old_state.reserved_amount;
-        if cmd.amount > avail_balance {
-            // In a real-world system this might emit a failure event rather than just silently absorb the command
-            error!(
-                "Rejecting command to reserve funds, account {} does not have sufficient funds.",
-                &cmd.account_number
-            );
-            Ok(vec![])
-        } else {
-            Ok(vec![Event::new(
-                WireFundsReserved::TYPE,
-                STREAM,
-                WireFundsReserved {
-                    account_number: cmd.account_number.to_string(),
-                    wire_transfer_id: cmd.wire_transfer_id,
-                    customer_id: old_state.customer_id.to_string(),
-                    amount: cmd.amount,
-                },
-            )])
-        }
-    }
-    fn handle_release_reserved_funds(
-        &self,
-        cmd: ReleaseReservedFunds,
-        state: Option<BankaccountAggregateState>,
-    ) -> Result<EventList> {
-        let Some(old_state) = state else {
-            error!(
-                "Rejected incoming command to release reserved funds. Account {} does not exist.",
-                cmd.account_number
-            );
-            return Ok(vec![]);
-        };
-        let adj_amount = cmd.amount.min(old_state.balance);
-        Ok(vec![Event::new(
-            WireFundsReleased::TYPE,
-            STREAM,
-            WireFundsReleased {
-                account_number: cmd.account_number.to_string(),
-                wire_transfer_id: cmd.wire_transfer_id.to_string(),
-                amount: adj_amount,
-            },
-        )])
-    }
-    fn handle_withdraw_funds(
-        &self,
-        cmd: WithdrawFunds,
-        state: Option<BankaccountAggregateState>,
-    ) -> Result<EventList> {
-        let Some(old_state) = state else {
-            error!(
-                "Rejected incoming command to withdraw funds. Account {} does not exist.",
-                cmd.account_number
-            );
-            return Ok(vec![]);
-        };
-
-        let avail_balance = old_state.balance - old_state.reserved_amount;
-        if avail_balance < cmd.amount {
-            error!(
-                "Rejected incoming command to withdraw funds. Insufficient funds in account {}",
-                cmd.account_number
-            );
-            return Ok(vec![]);
-        } else {
-            Ok(vec![Event::new(
-                FundsWithdrawn::TYPE,
-                STREAM,
-                FundsWithdrawn {
-                    account_number: cmd.account_number.to_string(),
-                    amount: cmd.amount,
-                    customer_id: old_state.customer_id,
-                    note: cmd.note,
-                },
-            )])
-        }
-    }
-
-    fn handle_withdraw_reserved_funds(
-        &self,
-        input: WithdrawReservedFunds,
-        state: Option<BankaccountAggregateState>,
-    ) -> Result<EventList> {
-        if state.is_none() {
-            error!(
-                "Rejecting withdraw reserved funds command. Account {} does not exist.",
-                input.account_number
-            );
-            return Ok(vec![]);
-        };
-
-        Ok(vec![Event::new(
-            ReservedFundsWithdrawn::TYPE,
-            STREAM,
-            ReservedFundsWithdrawn {
-                account_number: input.account_number.to_string(),
-                wire_transfer_id: input.wire_transfer_id.to_string(),
-                amount: input.amount,
-            },
-        )])
-    }
-
-    fn handle_deposit_funds(
-        &self,
-        cmd: DepositFunds,
-        state: Option<BankaccountAggregateState>,
-    ) -> Result<EventList> {
-        let Some(old_state) = state else {
-            error!(
-                "Rejected incoming command to withdraw funds. Account {} does not exist.",
-                cmd.account_number
-            );
-            return Ok(vec![]);
-        };
-
-        let avail_balance = old_state.balance - old_state.reserved_amount;
-        if avail_balance < cmd.amount {
-            error!(
-                "Rejected incoming command to withdraw funds. Insufficient funds in account {}",
-                cmd.account_number
-            );
-            return Ok(vec![]);
-        } else {
-            Ok(vec![Event::new(
-                FundsWithdrawn::TYPE,
-                STREAM,
-                FundsWithdrawn {
-                    account_number: cmd.account_number.to_string(),
-                    amount: cmd.amount,
-                    customer_id: old_state.customer_id,
-                    note: cmd.note,
-                },
-            )])
-        }
-    }
-    fn handle_request_wire_transfer(
-        &self,
-        cmd: RequestWireTransfer,
-        state: Option<BankaccountAggregateState>,
-    ) -> Result<EventList> {
-        let Some(old_state) = state else {
-            error!(
-                "Rejected incoming command to request a wire transfer. Account {} does not exist.",
-                cmd.account_number
-            );
-            return Ok(vec![]);
-        };
-
-        Ok(vec![Event::new(
-            WireTransferRequested::TYPE,
-            STREAM,
-            WireTransferRequested {
-                account_number: cmd.account_number.to_string(),
-                wire_transfer_id: cmd.wire_transfer_id,
-                amount: cmd.amount,
-                customer_id: old_state.customer_id,
-                target_account_number: cmd.target_account_number,
-                target_routing_number: cmd.target_routing_number,
-            },
-        )])
-    }
-    fn handle_initiate_interbank_transfer(
-        &self,
-        cmd: InitiateInterbankTransfer,
-        state: Option<BankaccountAggregateState>,
-    ) -> Result<EventList> {
-        if state.is_none() {
-            error!(
-                "Rejected incoming command to initiate bank transfer. Account {} does not exist.",
-                cmd.account_number
-            );
-            return Ok(vec![]);
-        };
-        // NOTE: validation would occur here in a real app
-        Ok(vec![Event::new(
-            InterbankTransferInitiated::TYPE,
-            STREAM,
-            InterbankTransferInitiated {
-                account_number: cmd.account_number.to_string(),
-                wire_transfer_id: cmd.wire_transfer_id,
-                target_account_number: cmd.target_account_number,
-                target_routing_number: cmd.target_routing_number,
-            },
-        )])
-    }
-
-    /* --- Event Appliers --- */
-
-    /// Update state with new account
-    fn apply_account_created(
-        &self,
-        input: AccountCreated,
-        _state: Option<BankaccountAggregateState>,
-    ) -> Result<StateAck> {
-        let state = BankaccountAggregateState {
-            balance: input.initial_balance,
-            min_balance: input.min_balance,
-            account_number: input.account_number,
-            customer_id: input.customer_id,
-            reserved_amount: 0,
-        };
-        Ok(StateAck::ok(Some(state)))
-    }
-
-    /// Add deposited funds to balance
-    fn apply_funds_deposited(
-        &self,
-        input: FundsDeposited,
-        state: Option<BankaccountAggregateState>,
-    ) -> Result<StateAck> {
-        let Some(old_state) = state else {
-            error!(
-                "Rejecting funds deposited event. Account {} does not exist.",
-                input.account_number
-            );
-            return Ok(StateAck::error("Account does not exist", None::<BankaccountAggregateState>));
-        };
-        let state = BankaccountAggregateState {
-            balance: old_state.balance + input.amount,
-            ..old_state
-        };
-        Ok(StateAck::ok(Some(state)))
-    }
-
-    /// Put reserved funds on hold
-    fn apply_wire_funds_reserved(
-        &self,
-        input: WireFundsReserved,
-        state: Option<BankaccountAggregateState>,
-    ) -> Result<StateAck> {
-        let Some(old_state) = state else {
-            error!(
-                "Rejecting funds reserved event. Account {} does not exist.",
-                input.account_number
-            );
-            return Ok(StateAck::error("Account does not exist", None::<BankaccountAggregateState>));
-        };
-
-        let state = BankaccountAggregateState {
-            reserved_amount: old_state.reserved_amount + input.amount,
-            ..old_state
-        };
-        Ok(StateAck::ok(Some(state)))
-    }
-
-    /// Withdraw funds from balance
-    fn apply_funds_withdrawn(
-        &self,
-        input: FundsWithdrawn,
-        state: Option<BankaccountAggregateState>,
-    ) -> Result<StateAck> {
-        let Some(old_state) = state else {
-            error!(
-                "Rejecting funds withdrawn event. Account {} does not exist.",
-                input.account_number
-            );
-            return Ok(StateAck::error("Account does not exist", None::<BankaccountAggregateState>));
-        };
-
-        let state = BankaccountAggregateState {
-            balance: old_state.balance - input.amount,
-            ..old_state
-        };
-        Ok(StateAck::ok(Some(state)))
-    }
-
-    /// Release previously reserved funds
-    fn apply_wire_funds_released(
-        &self,
-        input: WireFundsReleased,
-        state: Option<BankaccountAggregateState>,
-    ) -> Result<StateAck> {
-        let Some(old_state) = state else {
-            error!(
-                "Rejecting funds reserved event. Account {} does not exist.",
-                input.account_number
-            );
-            return Ok(StateAck::error("Account does not exist", None::<BankaccountAggregateState>));
-        };
-
-        let state = BankaccountAggregateState {
-            reserved_amount: old_state.reserved_amount - input.amount,
-            ..old_state
-        };
-        Ok(StateAck::ok(Some(state)))
-    }
-
-    /// Initiate an interbank transfer (which in turn triggers an external process)
-    fn apply_interbank_transfer_initiated(
-        &self,
-        _input: InterbankTransferInitiated,
-        state: Option<BankaccountAggregateState>,
-    ) -> Result<StateAck> {
-        // This is a no-op
-        Ok(StateAck::ok(state))
-    }
-
-    /// Update state with wire transfer request
-    fn apply_wire_transfer_requested(
-        &self,
-        _input: WireTransferRequested,
-        state: Option<BankaccountAggregateState>,
-    ) -> Result<StateAck> {
-        // currently a no-op
-        Ok(StateAck::ok(state))
-    }
-
-    fn apply_reserved_funds_withdrawn(
-        &self,
-        input: ReservedFundsWithdrawn,
-        state: Option<BankaccountAggregateState>,
-    ) -> Result<StateAck> {
-        let Some(old_state) = state else {
-            error!(
-                "Rejecting funds reserved event. Account {} does not exist.",
-                input.account_number
-            );
-            return Ok(StateAck::error("Account does not exist", None::<BankaccountAggregateState>));
-        };
-
-        // withdraw the amount on reserve, set amount on reserve to 0
-        let state = BankaccountAggregateState {
-            reserved_amount: 0,
-            balance: old_state.balance - input.amount,
-            ..old_state
-        };
-        Ok(StateAck::ok(Some(state)))
-    }
-}
-*/

--- a/examples/bankaccount/aggregate/src/state.rs
+++ b/examples/bankaccount/aggregate/src/state.rs
@@ -1,0 +1,69 @@
+use crate::*;
+
+#[derive(Serialize, Deserialize, Default, Debug, Clone)]
+pub struct BankAccountAggregateState {
+    pub balance: u32, // CENTS
+    pub min_balance: u32,
+    pub account_number: String,
+    pub customer_id: String,
+    pub reserved_funds: HashMap<String, u32>, // wire_transfer_id -> amount
+}
+
+impl BankAccountAggregateState {
+    /// Returns the regular balance minus the sum of transfer holds
+    pub fn available_balance(&self) -> u32 {
+        self.balance
+            .checked_sub(self.reserved_funds.values().sum::<u32>())
+            .unwrap_or(0)
+    }
+
+    /// Returns the total amount of funds on hold
+    pub fn total_reserved(&self) -> u32 {
+        self.reserved_funds.values().sum::<u32>()
+    }
+
+    /// Releases the funds associated with a wire transfer hold. Has no affect on actual balance, only available
+    pub fn release_funds(self, reservation_id: &str) -> Self {
+        let mut new_state = self.clone();
+        new_state.reserved_funds.remove(reservation_id);
+
+        new_state
+    }
+
+    /// Adds a reservation hold for a given wire transfer. Has no affect on actual balance, only available
+    pub fn reserve_funds(self, reservation_id: &str, amount: u32) -> Self {
+        let mut new_state = self.clone();
+        new_state
+            .reserved_funds
+            .insert(reservation_id.to_string(), amount);
+        new_state
+    }
+
+    /// Commits held funds. Subtracts held funds from balance. Note: A more realistic banking
+    /// app might emit an overdrawn/overdraft event if the new balance is less than 0. Here we
+    /// just floor the balance at 0. Also note that overcommits shouldn't happen because we reject
+    /// attempts to hold beyond available funds
+    pub fn commit_funds(self, reservation_id: &str) -> Self {
+        let mut new_state = self.clone();
+        let amount = new_state.reserved_funds.remove(reservation_id).unwrap_or(0);
+        new_state.balance = new_state.balance.checked_sub(amount).unwrap_or(0);
+        new_state
+    }
+
+    /// Withdraws a given amount of funds
+    pub fn withdraw(self, amount: u32) -> Self {
+        let mut new_state = self.clone();
+        new_state.balance = new_state.balance.checked_sub(amount).unwrap_or(0);
+        new_state
+    }
+
+    /// Deposits a given amount of funds. Ceilings at u32::MAX
+    pub fn deposit(self, amount: u32) -> Self {
+        let mut new_state = self.clone();
+        new_state.balance = new_state
+            .balance
+            .checked_add(amount)
+            .unwrap_or(new_state.balance);
+        new_state
+    }
+}


### PR DESCRIPTION
This PR contains an idiomatic implementation of an aggregate with a decent number of event and command handlers. It's just one opinion, but in this author's opinion it is pretty clean and easily read and maintained. It also reinforces the idea that the `&self` portion of a trait is just sugar and doesn't mean anything to the pure functions on the trait.

Also fixed a big logic bug in the old bank account aggregate which would lose its mind if two wire transfers were active at the same "time".